### PR TITLE
Export Deltas

### DIFF
--- a/src/Datetime/Types.hs
+++ b/src/Datetime/Types.hs
@@ -443,7 +443,7 @@ subDeltas d1 d2 = canonicalizeDelta $
 scaleDelta :: Int -> Delta -> Maybe Delta
 scaleDelta n (Delta (Period p) (Duration d))
   | n < 1     = Nothing
-  | otherwise = Just $
+  | otherwise = Just $ canonicalizeDelta $
       Delta (Period newPeriod) (Duration newDuration)
   where
     DH.Period py pm pd = p

--- a/src/Datetime/Types.hs
+++ b/src/Datetime/Types.hs
@@ -438,9 +438,12 @@ subDeltas d1 d2 = Delta (Period newPeriod) (Duration newDuration)
     newPeriod = DH.Period (max 0 pyr) (max 0 pmo) (max 0 pdy)
     newDuration = DH.Duration (max 0 dhr) (max 0 dmin) (max 0 dsec) 0
 
-scaleDelta :: Int -> Delta -> Delta
-scaleDelta n (Delta (Period p) (Duration d)) =
-   Delta (Period newPeriod) (Duration newDuration)
+-- | Scales all fields of a delta by a natural number n
+scaleDelta :: Int -> Delta -> Maybe Delta
+scaleDelta n (Delta (Period p) (Duration d))
+  | n < 1     = Nothing
+  | otherwise = Just $
+      Delta (Period newPeriod) (Duration newDuration)
   where
     DH.Period py pm pd = p
     DH.Duration (DH.Hours dh) (DH.Minutes dm) (DH.Seconds ds) _ = d

--- a/src/Datetime/Types.hs
+++ b/src/Datetime/Types.hs
@@ -9,22 +9,8 @@
 module Datetime.Types (
   Datetime(..),
   Delta(..),
-
   Period(..),
-  DH.periodYears,
-  DH.periodMonths,
-  DH.periodDays,
-
   Duration(..),
-  DH.durationHours,
-  DH.durationMinutes,
-  DH.durationSeconds,
-  DH.durationNs,
-  DH.Hours(..),
-  DH.Minutes(..),
-  DH.Seconds(..),
-  DH.NanoSeconds(..),
-
   Interval(..),
 
   -- ** Constructors
@@ -79,6 +65,8 @@ module Datetime.Types (
   -- ** Time Parse
   parseDatetime,
   formatDatetime,
+
+  displayDelta,
 
   -- ** System time
   now,
@@ -277,6 +265,25 @@ data Delta = Delta
   { dPeriod   :: Period   -- ^ An amount of conceptual calendar time in terms of years, months and days.
   , dDuration :: Duration -- ^ An amount of time measured in hours/mins/secs/nsecs
   } deriving (Show, Eq, Ord, Generic, NFData, Hashable, Serialize, ToJSON, FromJSON)
+
+displayDelta :: Delta -> Text
+displayDelta (Delta (Period (DH.Period y mo dy)) (Duration d)) =
+    year <> month <> day <> hour <> minute <> second
+  where
+    (DH.Duration (DH.Hours h) (DH.Minutes m) (DH.Seconds s) (DH.NanoSeconds ns)) = d
+
+    year  = suffix y  "y"
+    month = suffix mo "mo"
+    day   = suffix dy "d"
+
+    hour   = suffix h "h"
+    minute = suffix m "m"
+    second = suffix s "s"
+
+    suffix :: (Eq a, Num a, Show a) => a -> Text -> Text
+    suffix n s
+      | n == 0 = ""
+      | otherwise = show n <> s
 
 instance Monoid Delta where
   mempty = Delta mempty mempty

--- a/src/Datetime/Types.hs
+++ b/src/Datetime/Types.hs
@@ -11,6 +11,10 @@ module Datetime.Types (
   Delta(..),
   Period(..),
   Duration(..),
+  DH.Hours(..),
+  DH.Minutes(..),
+  DH.Seconds(..),
+  DH.NanoSeconds(..),
   Interval(..),
 
   -- ** Constructors

--- a/src/Datetime/Types.hs
+++ b/src/Datetime/Types.hs
@@ -9,6 +9,8 @@
 module Datetime.Types (
   Datetime(..),
   Delta(..),
+  Period(..),
+  Duration(..),
   Interval(..),
 
   -- ** Constructors
@@ -70,6 +72,8 @@ module Datetime.Types (
 
 import Protolude hiding (get, put, second, diff, from)
 
+import Control.Monad (fail)
+
 import Data.Aeson
 
 import Data.Hourglass
@@ -94,9 +98,6 @@ import qualified Data.Hourglass as DH
 
 import Data.Monoid ((<>))
 import Data.Serialize
-
-import Control.Monad (fail)
-import GHC.Generics (Generic)
 
 import Time.System (timezoneCurrent, dateCurrent)
 

--- a/src/Datetime/Types.hs
+++ b/src/Datetime/Types.hs
@@ -9,12 +9,22 @@
 module Datetime.Types (
   Datetime(..),
   Delta(..),
+
   Period(..),
+  DH.periodYears,
+  DH.periodMonths,
+  DH.periodDays,
+
   Duration(..),
+  DH.durationHours,
+  DH.durationMinutes,
+  DH.durationSeconds,
+  DH.durationNs,
   DH.Hours(..),
   DH.Minutes(..),
   DH.Seconds(..),
   DH.NanoSeconds(..),
+
   Interval(..),
 
   -- ** Constructors

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Main where
+
+import Protolude
 
 import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
@@ -8,8 +13,9 @@ import Test.Tasty.QuickCheck
 import Test.QuickCheck.Monadic
 
 import Data.List (unfoldr)
-import Data.Hourglass
-import Data.Hourglass.Types
+import qualified Data.Hourglass as DH
+import Data.Hourglass.Types as DH
+import qualified Data.Time.Calendar as DC
 import Data.Monoid ((<>))
 import Datetime
 import Datetime.Types
@@ -17,6 +23,24 @@ import Datetime.Types
 
 instance Arbitrary Datetime where
   arbitrary = posixToDatetime <$> choose (1, 32503680000) -- (01/01/1970, 01/01/3000)
+
+instance Arbitrary Period where
+  arbitrary = do
+    year <- choose (0,1000)
+    month <- choose (0,12)
+    let monthNumDays = DC.gregorianMonthLength (fromIntegral year) (fromIntegral month)
+    day <- choose (0,monthNumDays)
+    pure $ Period $ DH.Period year month day
+
+instance Arbitrary Duration where
+  arbitrary = fmap Duration $ DH.Duration
+    <$> (fmap Hours $ choose (0,23))
+    <*> (fmap Minutes $ choose (0,59))
+    <*> (fmap Seconds $ choose (0,59))
+    <*> pure 0
+
+instance Arbitrary Delta where
+  arbitrary = Delta <$> arbitrary <*> arbitrary
 
 instance Arbitrary TimezoneOffset where
   arbitrary = TimezoneOffset <$> choose (-660, 840)
@@ -93,6 +117,45 @@ suite = testGroup "Test Suite"
   , testProperty "dateTimeToDatetime . datetimeToDateTime = id" $ \(dt :: Datetime) ->
       (dateTimeToDatetime timezone_UTC $ datetimeToDateTime dt) == dt
 
+  , testProperty "Deltas are correctly added and canonicalized" $ \(Positive (Small n)) ->
+      let d1  = years 1  <> hours (n*24)
+          d2  = months 2 <> mins (n*60*24)
+          d3  = days 3   <> secs (n*60*60*24)
+      in (d1 <> d2 <> d3) == (years 1 <> months 2 <> days 3 <> days (n*3))
+
+  , testCase "Adding/Subtracting Deltas from Datetimes properly trim invalid month days" $ do
+      -- For adding/subtracting 1 month when month length differs
+      let mar31_2017 = Datetime 2017 3 31 0 0 0 0 5
+      let feb28_2017 = Datetime 2017 2 28 0 0 0 0 2
+      let jan31_2017 = Datetime 2017 1 31 0 0 0 0 2
+
+      -- For adding/subtracting 1 year when year length differs
+      let feb29_2016 = Datetime 2016 2 29 0 0 0 0 1
+      let feb28_2015 = Datetime 2015 2 28 0 0 0 0 6
+      let jan31_2015 = Datetime 2015 1 31 0 0 0 0 6
+
+      assertEqual "Mar 31 2017 - 1mo == Feb 28 2017"
+        (sub mar31_2017 $ months 1) feb28_2017
+      assertEqual "Jan 31 2017 + 1mo == Feb 28 2017"
+        (add jan31_2017 $ months 1) feb28_2017
+
+      assertEqual "Feb 29 2017 - 1yr == Feb 28 2015"
+        (sub feb29_2016 $ years 1) feb28_2015
+      assertEqual "Jan 31 2015 + 1yr1mo == Feb 29 2016"
+        (add jan31_2015 $ years 1 <> months 1) feb29_2016
+
+{-
+  , testProperty "Datetime + Delta - Delta == Datetime" $ \(dt, d) ->
+      monadicIO $ do
+        traceM ""
+        traceM $ "Delta:\n\t" <> show d
+        traceM $ "Original Datetime:\n    " <> show dt
+        let added = add dt d
+        traceM $ "Intermediate Datetime:\n    " <> show added
+        let subbed = sub added d
+        traceM $ "Resulting Datetime:\n    " <> show subbed
+        assert $ subbed == dt
+-}
   ]
 
 main :: IO ()

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -144,6 +144,20 @@ suite = testGroup "Test Suite"
       assertEqual "Jan 31 2015 + 1yr1mo == Feb 29 2016"
         (add jan31_2015 $ years 1 <> months 1) feb29_2016
 
+  , testCase "scaleDelta behaves correctly" $ do
+      let feb23_1999 = Datetime 1999 2 23 23 13 40 5 2
+      let testPeriod = Period (DH.Period 1 1 1)
+      let testDuration = Duration $ DH.Duration (DH.Hours 1) (DH.Minutes 1) (DH.Seconds 1) (DH.NanoSeconds 0)
+      let Just testDelta = scaleDelta 4 $ Delta testPeriod testDuration
+
+      let resPeriod = Period (DH.Period 4 4 4)
+      let resDuration = Duration $ DH.Duration (DH.Hours 4) (DH.Minutes 4) (DH.Seconds 4) (DH.NanoSeconds 0)
+      let resDelta = Delta resPeriod resDuration
+      assertEqual "4 * 1y1mo1d1h1m1s == 4y4mo4d4h4m4s" resDelta testDelta
+
+      let june28_2003 = Datetime 2003 6 28 3 17 44 5 6
+      assertEqual "Feb 23 1999 at 23:23:13 + 4y4mo4d4h4m4s == June 28 2003 3:17:44"
+        (add feb23_1999 testDelta) june28_2003
   ]
 
 main :: IO ()

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -144,18 +144,6 @@ suite = testGroup "Test Suite"
       assertEqual "Jan 31 2015 + 1yr1mo == Feb 29 2016"
         (add jan31_2015 $ years 1 <> months 1) feb29_2016
 
-{-
-  , testProperty "Datetime + Delta - Delta == Datetime" $ \(dt, d) ->
-      monadicIO $ do
-        traceM ""
-        traceM $ "Delta:\n\t" <> show d
-        traceM $ "Original Datetime:\n    " <> show dt
-        let added = add dt d
-        traceM $ "Intermediate Datetime:\n    " <> show added
-        let subbed = sub added d
-        traceM $ "Resulting Datetime:\n    " <> show subbed
-        assert $ subbed == dt
--}
   ]
 
 main :: IO ()


### PR DESCRIPTION
- [x] Export period & duration
- [x] Export hrs/mins/secs from Data.Hourglass
- [x] Export accessors from Data.Hoursglass
- [x] `displayDelta` (pretty print for FCL in uplink)
- [x] `canonicalizeDelta` to keep `Duration` < 24 hrs and overflow into `Period`
- [x] `dateAddPeriod` to add periods to datetime values
- [x] `scaleDelta`, multiplying deltas by a scalar value